### PR TITLE
Allow building on other docker accounts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ before_install:
   - cp ./Dockerfile certbot/Dockerfile
 
 install:
-  - docker build --rm --no-cache -t bcecchinato/certbot-rpi certbot/
-  - docker push bcecchinato/certbot-rpi
-  - docker tag bcecchinato/certbot-rpi bcecchinato/letsencrypt-rpi
-  - docker push bcecchinato/letsencrypt-rpi
+  - docker build --rm --no-cache -t "$DOCKER_USERNAME"/certbot-rpi certbot/
+  - docker push "$DOCKER_USERNAME"/certbot-rpi
+  - docker tag "$DOCKER_USERNAME"/certbot-rpi "$DOCKER_USERNAME"/letsencrypt-rpi
+  - docker push "$DOCKER_USERNAME"/letsencrypt-rpi
 
 script: true


### PR DESCRIPTION
Simple tweak to the Travis CI script that lets me easily set up my own pipeline for my own docker images.